### PR TITLE
Fixed empty filter rules in preference window.

### DIFF
--- a/chrome/content/ui/settings.js
+++ b/chrome/content/ui/settings.js
@@ -118,7 +118,10 @@ function init()
   E("listStack").addEventListener("keypress", onListKeyPress, true);
 
   // Use our fake browser with the findbar - and prevent default action on Enter key
-  E("findbar").browser = fastFindBrowser;
+  let findbar = E("findbar");
+  for (let prop in fastFindBrowser)
+    findbar[prop] = fastFindBrowser[prop];
+
   E("findbar").addEventListener("keypress", function(event)
   {
     // Work-around for bug 490047


### PR DESCRIPTION
See: https://issues.adblockplus.org/ticket/2041